### PR TITLE
Rewrite tests to use routes

### DIFF
--- a/query/base.py
+++ b/query/base.py
@@ -6,16 +6,6 @@ from application import cache
 class QueryBase:
     # summary
 
-    def get_summary(self, run_id):
-        return_dict = {}
-        for key, table in self.summary_table_map.items():
-            query = table.query.filter(table.run_id == run_id)
-            if key == 'properties':
-                return_dict[key] = query.one()
-            else:
-                return_dict[key] = query.all()
-        return return_dict
-
     def get_run_matches_paginated(self, run, family=None, page=1, perPage=20):
         run_id = run
         if family:

--- a/query/nucleotide.py
+++ b/query/nucleotide.py
@@ -1,6 +1,5 @@
 from .base import QueryBase
 from model.tables.nucleotide import (
-    nsra,
     nfamily,
     nsequence,
 )
@@ -14,11 +13,6 @@ from model.views.nucleotide import (
 
 class NucleotideQuery(QueryBase):
     def __init__(self):
-        self.summary_table_map = {
-            'properties': nsra,
-            'families': nfamily,
-            'sequences': nsequence
-        }
         # url param key : table model
         self.table_map = {
             'family': nfamily,

--- a/query/rdrp.py
+++ b/query/rdrp.py
@@ -1,6 +1,5 @@
 from .base import QueryBase
 from model.tables.rdrp import (
-    rsra,
     rphylum,
     rfamily,
     rsequence,
@@ -17,12 +16,6 @@ from model.views.rdrp import (
 
 class RdrpQuery(QueryBase):
     def __init__(self):
-        self.summary_table_map = {
-            'properties': rsra,
-            'phylums': rphylum,
-            'families': rfamily,
-            'sequences': rsequence
-        }
         # url param key : table model
         self.table_map = {
             'phylum': rphylum,

--- a/route/nucleotide.py
+++ b/route/nucleotide.py
@@ -3,10 +3,6 @@ from flask import current_app as app
 from query import nucleotide_query
 
 
-@app.route('/summary/nucleotide/run=<run_id>')
-def get_run_route(run_id):
-    return jsonify(**nucleotide_query.get_summary(run_id))
-
 @app.route('/matches/nucleotide')
 def get_matches_route():
     contents = nucleotide_query.get_matches_file(**request.args)

--- a/route/rdrp.py
+++ b/route/rdrp.py
@@ -3,10 +3,6 @@ from flask import current_app as app
 from query import rdrp_query
 
 
-@app.route('/summary/rdrp/run=<run_id>')
-def get_rdrp_run_route(run_id):
-    return jsonify(**rdrp_query.get_summary(run_id))
-
 @app.route('/matches/rdrp')
 def get_rdrp_matches_route():
     contents = rdrp_query.get_matches_file(**request.args)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,4 +5,9 @@ import json
 def get_response_data(route):
     with application.app.test_client() as client:
         response = client.get(route)
-    return json.loads(response.get_data(as_text=True))
+    return response.get_data(as_text=True)
+
+
+def get_response_json(route):
+    data = get_response_data(route)
+    return json.loads(data)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import application
+import json
+
+
+def get_response_data(route):
+    with application.app.test_client() as client:
+        response = client.get(route)
+    return json.loads(response.get_data(as_text=True))

--- a/tests/test_nucleotide.py
+++ b/tests/test_nucleotide.py
@@ -1,60 +1,59 @@
-import application
-from model.tables.nucleotide import nsra, nfamily, nsequence
-from query import nucleotide_query
+from . import get_response_data, get_response_json
 
 
 def test_run_summary():
-    result = nucleotide_query.get_summary('ERR2756788')
-    assert type(result['properties']) == nsra
-    assert len(result['families']) == 12
-    assert len(result['sequences']) == 349
+    pagination = get_response_json("/matches/nucleotide/run/paged?run=ERR2756788&perPage=10")
+    assert len(pagination['result']) == 10
+
+    pagination = get_response_json("/matches/nucleotide/run/paged?run=ERR2756788&family=Coronaviridae")
+    assert pagination['total'] == 231
 
 
 def test_download_family():
-    contents = nucleotide_query.get_matches_file(family='Coronaviridae', scoreMin=100)
+    contents = get_response_data("/matches/nucleotide?family=Coronaviridae&scoreMin=100")
     with open('tests/files/SerratusMatches-nucleotide-family-Coronaviridae.csv') as f:
         assert contents == f.read()
 
 
 def test_download_sequence():
-    contents = nucleotide_query.get_matches_file(sequence='EU769558.1', scoreMax=50)
+    contents = get_response_data("/matches/nucleotide?sequence=EU769558.1&scoreMax=50")
     with open('tests/files/SerratusMatches-nucleotide-sequence-EU769558.1.csv') as f:
         assert contents == f.read()
 
 
 def test_paginate_family():
-    pagination = nucleotide_query.get_matches_paginated(family='Coronaviridae', scoreMin=100)
-    assert len(pagination.items) == 20
-    assert pagination.items[0] == nfamily(run_id='SRR9966511', family_name='Coronaviridae', coverage_bins='mUmmUmmmUmUmmUmmUUmmUmUmm', score=100, percent_identity=99, depth=14.9, n_reads=2923, n_global_reads=401, length=30000)
-    assert pagination.total == 2839
+    pagination = get_response_json("/matches/nucleotide/paged?family=Coronaviridae&scoreMin=100")
+    assert len(pagination['result']) == 20
+    assert pagination['result'][0] == {'run_id': 'SRR9966511', 'family_name': 'Coronaviridae', 'family_id': 'Coronaviridae', 'coverage_bins': 'mUmmUmmmUmUmmUmmUUmmUmUmm', 'score': 100, 'percent_identity': 99, 'depth': 14.9, 'n_reads': 2923, 'n_global_reads': 401, 'length': 30000}
+    assert pagination['total'] == 2839
 
-    pagination = nucleotide_query.get_matches_paginated(family='Coronaviridae', scoreMin=100, perPage=3)
-    assert len(pagination.items) == 3
+    pagination = get_response_json("/matches/nucleotide/paged?family=Coronaviridae&scoreMin=100&perPage=3")
+    assert len(pagination['result']) == 3
 
 
 def test_paginate_sequence():
-    pagination = nucleotide_query.get_matches_paginated(sequence='EU769558.1', scoreMax=50)
-    assert len(pagination.items) == 20
-    assert pagination.items[0] == nsequence(run_id='ERR2756788', family_name='Coronaviridae', sequence_accession='EU769558.1', coverage_bins='aUAUmmm__________________', score=45, percent_identity=85, depth=9.6, n_reads=1694, n_global_reads=399, length=14335, virus_name='Bat coronavirus Trinidad/1CO7BA/2007 nonstructural protein 1b` gene, partial cds')
-    assert pagination.total == 365
+    pagination = get_response_json("/matches/nucleotide/paged?sequence=EU769558.1&scoreMax=50")
+    assert len(pagination['result']) == 20
+    assert pagination['result'][0] == {'run_id': 'ERR2756788', 'family_name': 'Coronaviridae', 'family_id': 'Coronaviridae', 'sequence_accession': 'EU769558.1', 'coverage_bins': 'aUAUmmm__________________', 'score': 45, 'percent_identity': 85, 'depth': 9.6, 'n_reads': 1694, 'n_global_reads': 399, 'length': 14335, 'virus_name': 'Bat coronavirus Trinidad/1CO7BA/2007 nonstructural protein 1b` gene, partial cds'}
+    assert pagination['total'] == 365
 
-    pagination = nucleotide_query.get_matches_paginated(sequence='EU769558.1', scoreMax=50, perPage=3)
-    assert len(pagination.items) == 3
+    pagination = get_response_json("/matches/nucleotide/paged?sequence=EU769558.1&scoreMax=50&perPage=3")
+    assert len(pagination['result']) == 3
 
 
 def test_counts():
-    counts = nucleotide_query.get_counts(family='Coronaviridae')
+    counts = get_response_json("/counts/nucleotide?family=Coronaviridae")
     assert len(counts) == 1320
     assert counts[10] == {'score': 1, 'percent_identity': 97, 'count': 43356}
 
-    counts = nucleotide_query.get_counts(sequence='EU769558.1')
+    counts = get_response_json("/counts/nucleotide?sequence=EU769558.1")
     assert len(counts) == 43
     assert counts[10] == {'score': 1, 'percent_identity': 100, 'count': 201}
 
 
 def test_list():
-    values_list = nucleotide_query.get_list('family')
+    values_list = get_response_json("/list/nucleotide/family")
     assert len(values_list) == 46
 
-    values_list = nucleotide_query.get_list('sequence')
+    values_list = get_response_json("/list/nucleotide/sequence")
     assert len(values_list) == 13187

--- a/tests/test_rdrp.py
+++ b/tests/test_rdrp.py
@@ -43,7 +43,6 @@ def test_paginate_sequence():
 def test_counts():
     counts = get_response_json("/counts/rdrp?family=Coronaviridae")
     assert len(counts) == 1387
-    print(counts[10])
     assert counts[10] == {'score': 1, 'percent_identity': 77, 'count': 10}
 
     counts = get_response_json("/counts/rdrp?sequence=NC_001653")

--- a/tests/test_rdrp.py
+++ b/tests/test_rdrp.py
@@ -3,10 +3,11 @@ from query import rdrp_query
 
 
 def test_run_summary():
-    result = get_response_json("/summary/rdrp/run=ERR2756788")
-    assert len(result['phylums']) == 6
-    assert len(result['families']) == 65
-    assert len(result['sequences']) == 123
+    pagination = get_response_json("/matches/rdrp/run/paged?run=ERR2756788&perPage=10")
+    assert len(pagination['result']) == 10
+
+    pagination = get_response_json("/matches/rdrp/run/paged?run=ERR2756788&family=Coronaviridae-1")
+    assert pagination['total'] == 13
 
 
 def test_download_phylum():

--- a/tests/test_rdrp.py
+++ b/tests/test_rdrp.py
@@ -1,5 +1,4 @@
 from . import get_response_data, get_response_json
-from query import rdrp_query
 
 
 def test_run_summary():

--- a/tests/test_rdrp.py
+++ b/tests/test_rdrp.py
@@ -1,18 +1,16 @@
-import application
-from model.tables.rdrp import rsra, rphylum, rfamily, rsequence
+from . import get_response_data, get_response_json
 from query import rdrp_query
 
 
 def test_run_summary():
-    result = rdrp_query.get_summary('ERR2756788')
-    assert type(result['properties']) == rsra
+    result = get_response_json("/summary/rdrp/run=ERR2756788")
     assert len(result['phylums']) == 6
     assert len(result['families']) == 65
     assert len(result['sequences']) == 123
 
 
 def test_download_phylum():
-    contents = rdrp_query.get_matches_file(phylum='Pisuviricota', scoreMin=100)
+    contents = get_response_data("/matches/rdrp?phylum=Pisuviricota&scoreMin=100")
     with open('tests/files/SerratusMatches-rdrp-phylum-Pisuviricota.csv') as f:
         assert contents == f.read()
 
@@ -22,40 +20,40 @@ def test_download_sequence():
 
 
 def test_paginate_phylum():
-    pagination = rdrp_query.get_matches_paginated(phylum='Pisuviricota', scoreMin=100)
-    assert len(pagination.items) == 20
-    assert pagination.items[0] == rphylum(run_id='SRR9320190', phylum_name='Pisuviricota', coverage_bins='UWAOOAAAAOOAAOAAOAAOMOAAm', score=100, percent_identity=61, depth=2064.0, n_reads=23389, aligned_length=44)
-    assert pagination.total == 65352
+    pagination = get_response_json("/matches/rdrp/paged?phylum=Pisuviricota&scoreMin=100")
+    assert len(pagination['result']) == 20
+    assert pagination['result'][0] == {'run_id': 'SRR9320190', 'phylum_name': 'Pisuviricota', 'coverage_bins': 'UWAOOAAAAOOAAOAAOAAOMOAAm', 'score': 100, 'percent_identity': 61, 'depth': 2064.0, 'n_reads': 23389, 'aligned_length': 44}
+    assert pagination['total'] == 65352
 
 
 def test_paginate_family():
-    pagination = rdrp_query.get_matches_paginated(family='Coronaviridae', scoreMin=100)
-    assert len(pagination.items) == 20
-    assert pagination.items[0] == rfamily(run_id='DRR220589', phylum_name='Pisuviricota', family_name='Coronaviridae', family_group='Coronaviridae-1', coverage_bins='aaawaawawaawawaaawwuawwwa', score=100, percent_identity=97, depth=37.1, n_reads=405, aligned_length=46)
-    assert pagination.total == 5310
+    pagination = get_response_json("/matches/rdrp/paged?family=Coronaviridae&scoreMin=100")
+    assert len(pagination['result']) == 20
+    assert pagination['result'][0] == {'run_id': 'DRR220589', 'phylum_name': 'Pisuviricota', 'family_name': 'Coronaviridae', 'family_group': 'Coronaviridae-1', 'family_id': 'Coronaviridae-1', 'coverage_bins': 'aaawaawawaawawaaawwuawwwa', 'score': 100, 'percent_identity': 97, 'depth': 37.1, 'n_reads': 405, 'aligned_length': 46}
+    assert pagination['total'] == 5310
 
 
 def test_paginate_sequence():
-    pagination = rdrp_query.get_matches_paginated(sequence='NC_001653', scoreMax=50)
-    assert len(pagination.items) == 20
-    assert pagination.items[0] == rsequence(run_id='SRR1595854', phylum_name='Deltavirus', family_name='Deltavirus', family_group='Deltavirus-1', virus_name='hdv1', sequence_accession='NC_001653', coverage_bins='_momauuu_woou_________ao_', score=49, percent_identity=81, depth=27.4, n_reads=447, aligned_length=31)
-    assert pagination.total == 166
+    data = get_response_json("/matches/rdrp/paged?sequence=NC_001653&scoreMax=50")
+    assert len(data['result']) == 20
+    assert data['result'][0] == {'run_id': 'SRR1595854', 'phylum_name': 'Deltavirus', 'family_name': 'Deltavirus', 'family_group': 'Deltavirus-1', 'family_id': 'Deltavirus-1', 'virus_name': 'hdv1', 'sequence_accession': 'NC_001653', 'coverage_bins': '_momauuu_woou_________ao_', 'score': 49, 'percent_identity': 81, 'depth': 27.4, 'n_reads': 447, 'aligned_length': 31}
+    assert data['total'] == 166
 
 
 def test_counts():
-    counts = rdrp_query.get_counts(family='Coronaviridae')
+    counts = get_response_json("/counts/rdrp?family=Coronaviridae")
     assert len(counts) == 1387
     print(counts[10])
     assert counts[10] == {'score': 1, 'percent_identity': 77, 'count': 10}
 
-    counts = rdrp_query.get_counts(sequence='NC_001653')
+    counts = get_response_json("/counts/rdrp?sequence=NC_001653")
     assert len(counts) == 135
     assert counts[10] == {'score': 1, 'percent_identity': 89, 'count': 1}
 
 
 def test_list():
-    values_list = rdrp_query.get_list('family')
+    values_list = get_response_json("/list/rdrp/family")
     assert len(values_list) == 2513
 
-    values_list = rdrp_query.get_list('sequence')
+    values_list = get_response_json("/list/rdrp/sequence")
     assert len(values_list) == 14669

--- a/tests/test_sra.py
+++ b/tests/test_sra.py
@@ -1,6 +1,6 @@
-from . import get_response_data
+from . import get_response_json
 
 
 def test_analysis_index_route():
-    data = get_response_data("/index/run=ERR2756788")
+    data = get_response_json("/index/run=ERR2756788")
     assert data == {'run_id': 'ERR2756788', 'srarun': True, 'nsra': True, 'psra': True, 'rsra': True, 'assembly': True, 'micro': True, 'geo': False}

--- a/tests/test_sra.py
+++ b/tests/test_sra.py
@@ -1,9 +1,6 @@
-import application
-import json
-from route.sra import get_index_run_route
+from . import get_response_data
 
 
 def test_analysis_index_route():
-    response = application.app.test_client().get("/index/run=ERR2756788")
-    data = json.loads(response.get_data(as_text=True))
+    data = get_response_data("/index/run=ERR2756788")
     assert data == {'run_id': 'ERR2756788', 'srarun': True, 'nsra': True, 'psra': True, 'rsra': True, 'assembly': True, 'micro': True, 'geo': False}


### PR DESCRIPTION
- use route-based tests for rdrp/nucleotide
- remove run summary routes/helpers, update tests for new routes