### PR TITLE
Add 'assembly_file' parameter for index route

### DIFF
--- a/model/views/sra.py
+++ b/model/views/sra.py
@@ -11,6 +11,7 @@ class analysis_index(db.Model):
     assembly : bool
     micro : bool
     geo : bool
+    assembly_file: str
 
     run_id = db.Column(db.Text, primary_key=True)
     srarun = db.Column(db.Boolean)
@@ -20,5 +21,6 @@ class analysis_index(db.Model):
     assembly = db.Column(db.Boolean)
     micro = db.Column(db.Boolean)
     geo = db.Column(db.Boolean)
+    assembly_file = db.Column(db.Text)
 
     filter_col_name = 'run_id'

--- a/tests/test_sra.py
+++ b/tests/test_sra.py
@@ -3,4 +3,4 @@ from . import get_response_json
 
 def test_analysis_index_route():
     data = get_response_json("/index/run=ERR2756788")
-    assert data == {'run_id': 'ERR2756788', 'srarun': True, 'nsra': True, 'psra': True, 'rsra': True, 'assembly': True, 'micro': True, 'geo': False}
+    assert data == {'run_id': 'ERR2756788', 'srarun': True, 'nsra': True, 'psra': True, 'rsra': True, 'assembly': True, 'micro': True, 'geo': False, 'assembly_file': 'ERR2756788.coronaspades.contigs.fa.mfc'}


### PR DESCRIPTION
Add a string for `assembly_file` to the analyis_index route. This is to create a button where the complete assembly for an SRA file can be automatically downloaded from the front-end.