### PR TITLE
Add new api endpoint to fetch rdrp_pos data

### DIFF
--- a/model/views/rdrp.py
+++ b/model/views/rdrp.py
@@ -68,3 +68,24 @@ class rsequence_list(db.Model):
     sequence_accession = db.Column(db.Text, primary_key=True)
     virus_name = db.Column(db.Text)
     filter_col_name = 'sequence_accession'
+
+@dataclass
+class srarun_geo_coordinates(db.Model):
+    run_id = db.Column(db.Text, primary_key=True)
+    biosample_id = db.Column(db.Text)
+    release_date = db.Column(db.DateTime)
+    coordinate_x = db.Column(db.Float)
+    coordinate_y = db.Column(db.Float)
+    from_text = db.Column(db.Text)
+
+@dataclass
+class rdrp_pos(db.Model):
+    run_id = db.Column(db.Text, primary_key=True)
+
+
+@dataclass
+class srarun(db.Model):
+    run = db.Column(db.Text, primary_key=True)
+    release_date = db.Column(db.DateTime)
+    tax_id = db.Column(db.Text)
+    scientific_name = db.Column(db.Text)

--- a/query/rdrp.py
+++ b/query/rdrp.py
@@ -11,7 +11,11 @@ from model.views.rdrp import (
     rphylum_list,
     rfamily_list,
     rsequence_list,
+    srarun_geo_coordinates,
+    rdrp_pos,
+    srarun,
 )
+from model import db
 
 
 class RdrpQuery(QueryBase):
@@ -32,3 +36,13 @@ class RdrpQuery(QueryBase):
             'family': rfamily_list,
             'sequence': rsequence_list
         }
+
+    def query_srarun_geo_coordnates(self, page, perPage):
+        query = db.session.query(srarun_geo_coordinates.run_id, srarun_geo_coordinates.biosample_id, srarun.release_date, srarun.tax_id,
+                 srarun.scientific_name, srarun_geo_coordinates.coordinate_x, srarun_geo_coordinates.coordinate_y,
+                 srarun_geo_coordinates.from_text)\
+                .join(rdrp_pos, srarun_geo_coordinates.run_id == rdrp_pos.run_id)\
+                .join(srarun, srarun_geo_coordinates.run_id == srarun.run)\
+                .distinct(srarun_geo_coordinates.run_id)\
+                .order_by(srarun_geo_coordinates.run_id)
+        return query.paginate(page=int(page), per_page=int(perPage))

--- a/tests/test_rdrp.py
+++ b/tests/test_rdrp.py
@@ -1,5 +1,6 @@
 import pytest
 from . import get_response_data, get_response_json
+from route.rdrp import validate_args
 
 
 def test_run_summary():
@@ -77,3 +78,59 @@ def test_list():
 
     values_list = get_response_json("/list/rdrp/sequence")
     assert len(values_list) == 14669
+
+
+def test_validate_args():
+    """
+    Test validate_args method
+    """
+    # Test a valid positive integer
+    assert validate_args('5') == 5
+
+    # Test a string that can be converted to a positive integer
+    assert validate_args('25') == 25
+
+    # Test a string that cannot be converted to an integer
+    assert validate_args('abc') == False
+
+    # Test a negative integer
+    assert validate_args('-5') == False
+
+    # Test 0
+    assert validate_args('0') == False
+
+
+def test_rdrp_pos():
+    """
+    Test rdrp_pos endpoint with query parameters
+    """
+    # Test default query (i.e. page = 1, perPage = 20)
+    rdrp_pos = get_response_json("/pos/rdrp")
+    assert len(rdrp_pos['result']) == 20
+    expected_output = {
+      "run_id": "DRR021440",
+      "biosample_id": "SAMD00018407",
+      "release_date": "Tue, 14 Jul 2015 10:38:15 GMT",
+      "tax_id": "318829",
+      "scientific_name": "Pyricularia oryzae",
+      "coordinate_x": -53.073466889,
+      "coordinate_y": -10.769946429,
+      "from_text": "brazil"
+    }
+    assert rdrp_pos['result'][0] == expected_output
+
+    # Test invalid page query param
+    rdrp_pos = get_response_json("/pos/rdrp?page=fail")
+    assert rdrp_pos['message'] == "Invalid page parameter: fail"
+
+    # Test invalid perPage query param
+    rdrp_pos = get_response_json("/pos/rdrp?perPage=fail")
+    assert rdrp_pos['message'] == "Invalid perPage parameter: fail"
+
+    # Test page query param
+    rdrp_pos = get_response_json("/pos/rdrp?page=3")
+    assert not (rdrp_pos['result'][0] == expected_output) # verifies the output is a different page
+
+    # Test perPage query param
+    rdrp_pos = get_response_json("/pos/rdrp?page=1&perPage=5")
+    assert len(rdrp_pos['result']) == 5


### PR DESCRIPTION
This PR adds a new api endpoint to fetch rdrp_pos data.

This is a part of the issue: https://github.com/serratus-bio/serratus.io/issues/225. Once this is merged, this api enpoint can be used by the RdRp Geo Map page.

Example Usage:

1. Default endpoint (without query parameters - Defaults to page 1 and perPage 20): /pos/rdrp 
```
{
  "result": [
    {
      "run_id": "DRR021440",
      "biosample_id": "SAMD00018407",
      "release_date": "Tue, 14 Jul 2015 10:38:15 GMT",
      "tax_id": "318829",
      "scientific_name": "Pyricularia oryzae",
      "coordinate_x": -53.073466889,
      "coordinate_y": -10.769946429,
      "from_text": "brazil"
    },
    {
      "run_id": "DRR021441",
      "biosample_id": "SAMD00018408",
      "release_date": "Tue, 14 Jul 2015 10:38:15 GMT",
      "tax_id": "318829",
      "scientific_name": "Pyricularia oryzae",
      "coordinate_x": -53.073466889,
      "coordinate_y": -10.769946429,
      "from_text": "brazil"
    },
    .
    .
    .
    ]
}
```

2. Endpoints with parameters: /pos/rdrp?page=6&perPage=2
```
{
  "result": [
    {
      "run_id": "DRR022329",
      "biosample_id": "SAMD00019235",
      "release_date": "Tue, 09 Jan 2018 20:09:36 GMT",
      "tax_id": "941566",
      "scientific_name": "Enkianthus perulatus",
      "coordinate_x": 134.22217792,
      "coordinate_y": 35.49441833,
      "from_text": "japan: tottori"
    },
    {
      "run_id": "DRR022330",
      "biosample_id": "SAMD00019235",
      "release_date": "Tue, 09 Jan 2018 20:09:37 GMT",
      "tax_id": "941566",
      "scientific_name": "Enkianthus perulatus",
      "coordinate_x": 134.22217792,
      "coordinate_y": 35.49441833,
      "from_text": "japan: tottori"
    }
  ]
}
```



Signed-off-by: Pooja Kulkarni <poojakulkarni8691@gmail.com>