### PR TITLE
Downgrade Flask-SQLAlchemy@3.0.0 and SQLAlchemy@1.4.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 cachelib
 flask
 flask-cors
-Flask-SQLAlchemy
+Flask-SQLAlchemy==3.0.0
+SQLAlchemy==1.4.18
 Flask-SQLAlchemy-Caching
 psycopg2-binary
 pytest


### PR DESCRIPTION
Summary of issue:

- On Feb 28 the instance was taken out of service in response to an EC2 scheduled reboot ([see logs](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#AutoScalingGroupDetails:id=awseb-e-uyxetxumt5-stack-AWSEBAutoScalingGroup-1IGSBE3OJT9LB;view=activity))
- This caused the host to force a reinstall of pip requirements which upgraded Flask-SQLAlchemy from <3.0.0 to 3.0.3
- The host began throwing the error:
  ```
  sqlalchemy.exc.ArgumentError: Type annotation for "nfamily.family_id" can't be correctly interpreted for Annotated Declarative Table form.  ORM annotations should normally make use of the ``Mapped[]`` generic type, or other ORM-compatible generic type, as a container for the actual type, which indicates the intent that the attribute is mapped. Class variables that are not intended to be mapped by the ORM should use ClassVar[].  To allow Annotated Declarative to disregard legacy annotations which don't use Mapped[] to pass, set "__allow_unmapped__ = True" on the class or a superclass this class. (Background on this error at: https://sqlalche.me/e/20/zlpr)
  ```
- You can simulate this on your machine by forcing a new install, checking version changes, then running the server
  ```
  pip3 install -r requirements.txt --force-reinstall
  pip3 freeze | grep -E 'Flask-SQLAlchemy|SQLAlchemy'
  ```

Other notes:
- Since we're not using a virtual env, it's probably best to include the explicit versions for all packages in requirements.txt. I can look into opening a follow up PR with those changes after this hotfix ([see stackoverflow](https://stackoverflow.com/a/55052493)).
- We can also consider following the migration steps to the new version of Flask-SQLAlchemy mentioned in the error message, though there seems to be more changes needed after fixing the initial error ([see docs](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-20-step-six)). 
