### PR TITLE
Add versions to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-cachelib
-flask
-flask-cors
+cachelib==0.9.0
+flask==2.2.3
+flask-cors==3.0.10
 Flask-SQLAlchemy==3.0.0
+Flask-SQLAlchemy-Caching==1.0.4
+psycopg2-binary==2.9.5
+pytest==7.2.1
 SQLAlchemy==1.4.18
-Flask-SQLAlchemy-Caching
-psycopg2-binary
-pytest


### PR DESCRIPTION
This is a follow-up to an issue of instance going down because dependencies updated to new major version that caused breaking changes in SQLAlchemy. Fixed in [this PR](https://github.com/serratus-bio/serratus-summary-api/pull/35/files).

Since future scheduled reboots of hosts can cause library updates with breaking changes, the API would be more stable if we include versions in the `requirements.txt`. Even though this is a common practice, there are still other lower-risk issues since we won't receive updated libraries until we manually change the `requirements.txt`.

Testing:
- Confirmed `bash run.sh` works as expected
- Confirmed `bash test.sh` passes all tests
 