### PR TITLE
Add workaround for cache on geo endpoint

### DIFF
--- a/query/geo.py
+++ b/query/geo.py
@@ -1,6 +1,3 @@
-from flask_sqlalchemy_caching import FromCache
-from application import cache
-
 from model.tables.sra import (
     srarun,
 )
@@ -29,8 +26,7 @@ def get_geo_rdrp_paginated(page=1, perPage=500):
         .join(rdrp_pos, srarun_geo_coordinates.run_id == rdrp_pos.run_id)
         .join(srarun, srarun_geo_coordinates.run_id == srarun.run)
         .distinct(srarun_geo_coordinates.run_id)
-        .order_by(srarun_geo_coordinates.run_id)
-        .options(FromCache(cache)))
+        .order_by(srarun_geo_coordinates.run_id))
     pagination = query.paginate(page=int(page), per_page=int(perPage))
     pagination.items = [entry._asdict() for entry in pagination.items]
     return pagination

--- a/route/geo.py
+++ b/route/geo.py
@@ -1,9 +1,11 @@
 from flask import jsonify, request
 from flask import current_app as app
 from query import get_geo_rdrp_paginated
+from application import cache
 
 
 @app.route('/geo/rdrp/paged')
+@cache.cached(query_string=True)
 def get_geo_rdrp_paginated_route():
     pagination = get_geo_rdrp_paginated(**request.args)
     total = pagination.total


### PR DESCRIPTION
This PR unblocks the task of fetching geo data from the API, however we may want to explore other improvements to this endpoint and our cache mentioned in https://github.com/serratus-bio/serratus.io/issues/225#issuecomment-1468849672

This change is needed because the package for [Flask-SQLAlchemy-Caching](https://pypi.org/project/Flask-SQLAlchemy-Caching/) is not working and doesn't seem to be maintained. I tried for some time to get the `FromCache` option to work but wasn't able to, so instead of using `FromCache` on the SQL query we can use the cache decorator on the route which has the same functionality. I can look into a full migration away from this library and an improved cache strategy in a follow up as part of https://github.com/serratus-bio/serratus-summary-api/issues/38