### PR TITLE
Add run_id filter to geo endpoint

### DIFF
--- a/query/geo.py
+++ b/query/geo.py
@@ -9,7 +9,7 @@ from model.views.geo import (
 )
 
 
-def get_geo_rdrp_paginated(page=1, perPage=500):
+def get_geo_rdrp_paginated(page=1, perPage=500, run=''):
     select_columns = [
         srarun_geo_coordinates.run_id,
         srarun_geo_coordinates.biosample_id,
@@ -20,11 +20,16 @@ def get_geo_rdrp_paginated(page=1, perPage=500):
         srarun_geo_coordinates.coordinate_y,
         srarun_geo_coordinates.from_text
     ]
+    filters = []
+    if run:
+        filters.append(srarun_geo_coordinates.run_id.in_(run.split(',')))
+
     query = (
         srarun_geo_coordinates.query
         .with_entities(*select_columns)
         .join(rdrp_pos, srarun_geo_coordinates.run_id == rdrp_pos.run_id)
         .join(srarun, srarun_geo_coordinates.run_id == srarun.run)
+        .filter(*filters)
         .distinct(srarun_geo_coordinates.run_id)
         .order_by(srarun_geo_coordinates.run_id))
     pagination = query.paginate(page=int(page), per_page=int(perPage))

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -2,9 +2,9 @@ from . import  get_response_json
 
 
 def test_paginate_geo():
-    rdrp_pos = get_response_json("/geo/rdrp/paged?page=1&perPage=10")
-    assert len(rdrp_pos['result']) == 10
-    assert rdrp_pos['result'][0] == {
+    first_page = get_response_json("/geo/rdrp/paged?page=1&perPage=10")
+    assert len(first_page['result']) == 10
+    assert first_page['result'][0] == {
       "run_id": "DRR021440",
       "biosample_id": "SAMD00018407",
       "release_date": "Tue, 14 Jul 2015 10:38:15 GMT",
@@ -15,10 +15,9 @@ def test_paginate_geo():
       "from_text": "brazil"
     }
 
-
-    rdrp_pos = get_response_json("/geo/rdrp/paged?page=6&perPage=5")
-    assert len(rdrp_pos['result']) == 5
-    assert rdrp_pos['result'][0] == {
+    sixth_page = get_response_json("/geo/rdrp/paged?page=6&perPage=5")
+    assert len(sixth_page['result']) == 5
+    assert sixth_page['result'][0] == {
         "run_id":	"DRR029069",
         "biosample_id":	"SAMD00024757",
         "release_date":	"Mon, 26 Jan 2015 10:28:36 GMT",
@@ -28,3 +27,34 @@ def test_paginate_geo():
         "coordinate_y":	5.067,
         "from_text":	None,
     }
+
+def test_geo_run_filter():
+    expected = {
+          "DRR021440" : {
+            "run_id":	"DRR021440",
+            "biosample_id":	"SAMD00018407",
+            "release_date":	"Tue, 14 Jul 2015 10:38:15 GMT",
+            "tax_id":	"318829",
+            "scientific_name":	"Pyricularia oryzae",
+            "coordinate_x":	-53.073466889,
+            "coordinate_y":	-10.769946429,
+            "from_text":	"brazil",
+          },
+        "SRR13187411": {
+            "run_id":	"SRR13187411",
+            "biosample_id":	"SAMN16984707",
+            "release_date":	"Wed, 02 Dec 2020 19:04:46 GMT",
+            "tax_id":	"2697049",
+            "scientific_name":	"Severe acute respiratory syndrome coronavirus 2",
+            "coordinate_x":	-91.0969,
+            "coordinate_y":	30.5694,
+            "from_text":	None
+        }
+    }
+
+    single_run = get_response_json("/geo/rdrp/paged?run=DRR021440")
+    assert single_run['result'][0] == expected['DRR021440']
+
+    multiple_runs = get_response_json("/geo/rdrp/paged?run=DRR021440,SRR13187411")
+    assert multiple_runs['result'][0] == expected['DRR021440']
+    assert multiple_runs['result'][1] == expected['SRR13187411']


### PR DESCRIPTION
Small change to filter requests for geo data by a list of run_ids. This will later allow us to embed the Geo page inside the explorer page.

Notes, using 'run' as the parameter to remain consistent with existing query params